### PR TITLE
Added addColumn() method

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -91,7 +91,27 @@ class Table {
             this->name = name;
         }
 
-        void addColumns() {}
+        void addColumn(string fieldName, FieldDataType fieldDataType) {
+            FieldData field = FieldData();
+            field.name = fieldName;
+            field.dataType = fieldDataType;
+
+            // Add a new column, and put its index into field
+            // We will use the index later to get the correct column
+            switch (fieldDataType) {
+                case FieldDataType::INT:
+                    dataInt.push_back(vector<int>());
+                    field.columnIndex = dataInt.size() - 1;
+                    break;
+                case FieldDataType::TEXT:
+                    dataStr.push_back(vector<string>());
+                    field.columnIndex = dataStr.size() - 1;
+                    break;
+            }
+
+            fieldDataList.push_back(field);
+        }
+
         void selectRows() {}
         void insertRows() {}
         void deleteRows() {}
@@ -334,16 +354,7 @@ void createTable(vector<string> tokens, Table& table) {
             exit(1);
         }
 
-        FieldData fieldData;
-        fieldData.name = fieldName;
-        fieldData.dataType = fieldDataType;
-
-        cout << "Field name: " << fieldData.name << '\n';
-        cout << "Field data type: " << dataTypeStr << "\n\n";
-
-        // This is just a stub, so it won't do anything for now
-        // But this is how you access public class methods
-        table.addColumns();
+        table.addColumn(fieldName, fieldDataType);
 
         // Skip the comma
         index++;


### PR DESCRIPTION
This is the way `Table` will be constructed:

`Table` will have `dataStr` and `dataInt`, which is a list of columns. Since we have two different data types here, we have to use two list of columns. This means that each column may be in `dataStr` or `dataInt`, depending on the `FieldDataType.dataType`.

Each `FieldData` will contain 3 parameters: its name, data type, and column index.
Name and data type is straightforward.

Column index refer to the index of the column in either `dataStr` or `dataInt`.

For example:
Let's say that the `fieldDataList` have 3 elements:

```cpp
fieldDataList[0].name = "student_name";
fieldDataList[0].dataType = FieldDataType::TEXT;
fieldDataList[0].columnIndex = 0;

fieldDataList[1].name = "student_id";
fieldDataList[1].dataType = FieldDataType::INT;
fieldDataList[1].columnIndex = 0;

fieldDataList[2].name = "address";
fieldDataList[2].dataType = FieldDataType::TEXT;
fieldDataList[2].columnIndex = 1;
```

This meant that:
1. We have 3 columns in total
2. `dataInt` has 1 element, but `dataStr` has 2 elements (note that 'element' here refers to `vector<int>` or `vector<string>`)
3. The column `student_name` refer to `dataStr[0]`
4. The column `student_id` refer to `dataInt[0]`
5. The column `address` refer to `dataStr[1]`